### PR TITLE
fix: wierd delete-then-create

### DIFF
--- a/gennaker_tools/settings_sync_extension.py
+++ b/gennaker_tools/settings_sync_extension.py
@@ -307,8 +307,19 @@ class SettingsSyncApp(ExtensionApp):
             stop_event=self._event,
             watch_filter=lambda change, path: self.path_is_tracked(path),
         ):
-            for change, _path in changes:
-                path = pathlib.Path(_path)
+            it_changes = iter((c, pathlib.Path(p)) for c, p in changes)
+            for change, path in it_changes:
+                # Catch delete-recreate modification strategy
+                if change == watchfiles.Change.deleted and path.exists():
+                    next_change, next_path = next(it_changes)
+                    assert next_path == path
+                    assert next_change == watchfiles.Change.added
+
+                    change = watchfiles.Change.modified
+                    self.log.debug(
+                        f"Rewriting delete-then-create as modification: {path}"
+                    )
+
                 event = (
                     FileSystemEvent.deleted
                     if change == watchfiles.Change.deleted


### PR DESCRIPTION
Vim appears to use delete-then-create as a write strategy. This is too fast for the sync extension; by the time we get the deletion event, the creation event has already taken effect and the file is present on the disk. This means that testing `file.exists()` breaks.

The workaround is just to detect delete-but-file-exists and rewrite these events.