### PR TITLE
Fix `saveAs` command

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,13 @@ import { statelessRunPlugin } from './statelessRun.js';
 import { tomlSyncPlugin } from './tomlSync.js';
 import { saveAsPlugin } from './saveAs.js';
 
-export { snippetsPlugin, statelessRunPlugin, reloadPlugin, tomlSyncPlugin, saveAsPlugin };
+export {
+  snippetsPlugin,
+  statelessRunPlugin,
+  reloadPlugin,
+  tomlSyncPlugin,
+  saveAsPlugin
+};
 export default [
   statelessRunPlugin,
   reloadPlugin,

--- a/src/saveAs.ts
+++ b/src/saveAs.ts
@@ -3,14 +3,30 @@ import {
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
 import { showDialog, Dialog } from '@jupyterlab/apputils';
-import { ITranslator, nullTranslator } from '@jupyterlab/translation';
+import {
+  ITranslator,
+  nullTranslator,
+  TranslationBundle
+} from '@jupyterlab/translation';
 import { Widget } from '@lumino/widgets';
 import { IDocumentManager } from '@jupyterlab/docmanager';
-import { IContentsManager } from '@jupyterlab/services';
+import type { DocumentRegistry } from '@jupyterlab/docregistry';
+import { IContentsManager, Contents } from '@jupyterlab/services';
+
 /**
- * Initialization data for the gennaker-tools extension.
+ * Create the node for a save widget.
  */
-class SaveWidget extends Widget {
+function createSaveNode(path: string): HTMLElement {
+  const input = document.createElement('input');
+  input.value = path;
+  return input;
+}
+
+namespace Private {
+  /**
+   * Initialization data for the gennaker-tools extension.
+   */
+  class SaveWidget extends Widget {
     /**
      * Construct a new save widget.
      */
@@ -26,14 +42,54 @@ class SaveWidget extends Widget {
     }
   }
 
-  /**
-   * Create the node for a save widget.
-   */
-  function createSaveNode(path: string): HTMLElement {
-    const input = document.createElement('input');
-    input.value = path;
-    return input;
+  export async function getSavePath(
+    trans: TranslationBundle,
+    localPath: string
+  ): Promise<string | undefined> {
+    const saveBtn = Dialog.okButton({
+      label: trans.__('Save'),
+      accept: true
+    });
+    const result = await showDialog({
+      title: trans.__('Save File As…'),
+      body: new SaveWidget(localPath),
+      buttons: [Dialog.cancelButton(), saveBtn]
+    });
+    if (result.button.accept) {
+      return result.value ?? undefined;
+    }
+    return;
   }
+
+  /**
+   * Vendors https://github.com/jupyterlab/jupyterlab/blob/c56dc89e73db208515710e01ec42baf8f26fe2e2/packages/docregistry/src/context.ts#L308-L333
+   * into our codebase, so we can patch it and use it.
+   */
+  export async function vendoredSaveAs(
+    contents: Contents.IManager,
+    context: DocumentRegistry.Context,
+    newPath: string
+  ) {
+    // Make sure the path does not exist.
+    try {
+      await contents.get(newPath, {
+        contentProviderId: (context as any)._contentProviderId,
+        content: false
+      });
+      await (context as any)._maybeOverWrite(newPath);
+    } catch (err: any) {
+      if (!err.response || err.response.status !== 404) {
+        // Dialog rejection (user cancelled)
+        if (!err.response) {
+          return false;
+        }
+        throw err;
+      }
+    }
+    await (context as any)._finishSaveAs(newPath);
+  }
+}
+
 export const saveAsPlugin: JupyterFrontEndPlugin<void> = {
   id: 'gennaker-tools:save-as',
   description: 'A JupyterLab extension.',
@@ -43,43 +99,46 @@ export const saveAsPlugin: JupyterFrontEndPlugin<void> = {
   activate: (
     app: JupyterFrontEnd,
     docManager: IDocumentManager,
-    contents: IContentsManager,
+    contents: Contents.IManager,
     translator: ITranslator | null
   ) => {
     const trans = (translator ?? nullTranslator).load('jupyterlab');
     const { commands, shell } = app;
 
     console.log('JupyterLab plugin gennaker-tools:save-as is activated!');
-    // Add a command
 
-    // TODO: move to another location
-        commands.addCommand('gennaker-tools:save-as', {
-        label: () =>
-        "Save as",
-        caption: 'Save with new path',
-        isEnabled: () => true,
-        describedBy: {
+    commands.addCommand('gennaker-tools:save-as', {
+      label: () => 'Save As',
+      caption: 'Save with new path',
+      isEnabled: () => true,
+      describedBy: {
         args: {
-            type: 'object',
-            properties: {}
+          type: 'object',
+          properties: {}
         }
-        },
-        execute: () => {
-            const context = docManager.contextForWidget(shell.currentWidget!);
-            const localPath = docManager.contents.localPath(context.path);
-            console.log("testing new save as")
-            const saveBtn = Dialog.okButton({ label: trans.__('Save'), accept: true });
-            return showDialog({
-            title: trans.__('Save File As…'),
-            body: new SaveWidget("test_path"),
-            buttons: [Dialog.cancelButton(), saveBtn]
-            }).then(result => {
-            if (result.button.accept) {
-                return result.value ?? undefined;
-            }
-            return;
-            });
+      },
+      execute: async () => {
+        const context = docManager.contextForWidget(shell.currentWidget!)!;
+        const localPath = contents.localPath(context.path);
+        const newLocalPath = await Private.getSavePath(trans, localPath);
+
+        const drive = contents.driveName(context.path);
+        const newPath =
+          drive === '' ? newLocalPath : `${drive}:${newLocalPath}`;
+        if (!newPath) {
+          return;
         }
-    })
+
+        if (newPath === context.path) {
+          await context.save();
+          return;
+        }
+
+        // FIXME: Hacky! JupyterLab expects to be able to break this API, because
+        //        it's private.
+        // Call JupyterLab's internal implementation
+        Private.vendoredSaveAs(contents, context, newPath);
+      }
+    });
   }
 };

--- a/src/statelessRun.ts
+++ b/src/statelessRun.ts
@@ -26,7 +26,6 @@ export const statelessRunPlugin: JupyterFrontEndPlugin<void> = {
     const { commands, shell } = app;
 
     console.log('JupyterLab plugin gennaker-tools:stateless-run is activated!');
-    // Add a command
 
     const isEnabled = () => {
       return (


### PR DESCRIPTION
This PR closes off the work with @pascargr to fix `save-as`. This has been hard to implement cleanly, because the save-as logic is fairly "built-in", whilst we only want to make a minor modification.

To work around this, we tell TypeScript to let us do bad things!